### PR TITLE
fix: Fix _cudadecon_version annotation, added support for skewed decon argument

### DIFF
--- a/src/pycudadecon/_libwrap.py
+++ b/src/pycudadecon/_libwrap.py
@@ -5,9 +5,9 @@ import numpy as np
 from typing_extensions import Annotated
 
 from ._ctyped import Library
-
+from typing import Tuple
 # FIXME: ugly... we should export version better from cudadecon
-_cudadecon_version: tuple(int(x) for x in (0, 0, 0))
+_cudadecon_version: Tuple[int, ...] = (0, 0, 0)
 _conda_prefix = os.getenv("CONDA_PREFIX")
 if _conda_prefix:
     conda_meta = Path(_conda_prefix) / "conda-meta"

--- a/src/pycudadecon/_libwrap.py
+++ b/src/pycudadecon/_libwrap.py
@@ -75,7 +75,7 @@ if _cudadecon_version < (0, 6):
         OTF_file_name: file name of OTF
         """
 
-else:
+else: # include "bSkewDecon" arguement
 
     @lib.function
     def RL_interface_init(

--- a/src/pycudadecon/_libwrap.py
+++ b/src/pycudadecon/_libwrap.py
@@ -7,7 +7,7 @@ from typing_extensions import Annotated
 from ._ctyped import Library
 
 # FIXME: ugly... we should export version better from cudadecon
-_cudadecon_version: tuple[int, ...] = (0, 0, 0)
+_cudadecon_version: tuple(int(x) for x in (0, 0, 0))
 _conda_prefix = os.getenv("CONDA_PREFIX")
 if _conda_prefix:
     conda_meta = Path(_conda_prefix) / "conda-meta"

--- a/src/pycudadecon/deconvolution.py
+++ b/src/pycudadecon/deconvolution.py
@@ -62,7 +62,8 @@ def rl_init(
     width : int, optional
         If deskewed, the output image's width, by default 0 (do not crop)
     skewed_decon : bool, optional
-        If True, perform deconvolution in skewed space, by default False.
+        If True, perform deconvolution in skewed space, by default False. Same as the "-dcbds" command line option.
+        If deskewing, do it after decon; require sample-scan PSF and non-Rotational Averaged 3D OTF
 
     Examples
     --------
@@ -75,7 +76,7 @@ def rl_init(
 
     args: list = [nx, ny, nz, dxdata, dzdata, dxpsf, dzpsf, deskew, rotate, width]
 
-    if lib.lib.version >= (0, 6):
+    if lib.lib.version >= (0, 6):   # must have cudadecon library >= 0.6.0
         args += [skewed_decon]
 
     lib.RL_interface_init(*args, otfpath.encode())
@@ -215,7 +216,7 @@ def quickDecon(
 class RLContext:
     """Context manager to setup the GPU for RL decon.
 
-    Takes care of handing the OTF to the GPU, preparing a cuFFT plan,
+    Takes care of handing the OTF to the GPU, preparing a cuFFT plane,
     and cleaning up after decon.  Internally, this calls :func:`rl_init`,
     stores the shape of the expected output volume after any deskew/decon,
     then calls :func:`rl_cleanup` when exiting the context.

--- a/src/pycudadecon/deconvolution.py
+++ b/src/pycudadecon/deconvolution.py
@@ -239,6 +239,7 @@ class RLContext:
         deskew: float = 0,
         rotate: float = 0,
         width: int = 0,
+        skewed_decon: bool = False,
     ):
         self.kwargs = {
             "rawdata_shape": rawdata_shape,
@@ -250,6 +251,7 @@ class RLContext:
             "deskew": deskew,
             "rotate": rotate,
             "width": width,
+            "skewed_decon": skewed_decon,
         }
         self.out_shape: Optional[Tuple[int, int, int]] = None
 

--- a/src/pycudadecon/deconvolution.py
+++ b/src/pycudadecon/deconvolution.py
@@ -215,7 +215,7 @@ def quickDecon(
 class RLContext:
     """Context manager to setup the GPU for RL decon.
 
-    Takes care of handing the OTF to the GPU, preparing a cuFFT plane,
+    Takes care of handing the OTF to the GPU, preparing a cuFFT plan,
     and cleaning up after decon.  Internally, this calls :func:`rl_init`,
     stores the shape of the expected output volume after any deskew/decon,
     then calls :func:`rl_cleanup` when exiting the context.


### PR DESCRIPTION
Fixed `_cudadecon_version: tuple[int, ...] = (0, 0, 0) ` from throwing an exception.

Working on Windows with cudadecon 0.6.2. 