### PR TITLE
feat: add arguments for 3D OTF generation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,4 +138,4 @@ ignore = [
 ]
 
 [tool.typos.default]
-extend-ignore-identifiers-re = ["(?i)otfs?.*", "(?i)nd2"]
+extend-ignore-identifiers-re = ["(?i)otfs?.*", "(?i)nd2", "(?i)b3Dout"]

--- a/src/pycudadecon/_libwrap.py
+++ b/src/pycudadecon/_libwrap.py
@@ -253,6 +253,7 @@ except FileNotFoundError:
     ) from None
 
 if lib.version and lib.version < (0, 7):
+
     @otf_lib.function
     def makeOTF(
         ifiles: bytes,
@@ -271,6 +272,7 @@ if lib.version and lib.version < (0, 7):
         """Make OTF file(s) from `ifiles`, write to `ofiles`."""
 
 else:
+
     @otf_lib.function
     def makeOTF(
         ifiles: bytes,

--- a/src/pycudadecon/_libwrap.py
+++ b/src/pycudadecon/_libwrap.py
@@ -252,7 +252,7 @@ except FileNotFoundError:
         "Please try `conda install -c conda-forge cudadecon`."
     ) from None
 
-if otf_lib.version and otf_lib.version < (0, 7):
+if lib.version and lib.version < (0, 7):
 
     @otf_lib.function
     def makeOTF(

--- a/src/pycudadecon/_libwrap.py
+++ b/src/pycudadecon/_libwrap.py
@@ -248,21 +248,39 @@ except FileNotFoundError:
         "Please try `conda install -c conda-forge cudadecon`."
     ) from None
 
+if lib.version and lib.version < (0, 7):
+    @otf_lib.function
+    def makeOTF(
+        ifiles: bytes,
+        ofiles: bytes,
+        lambdanm: int = 520,
+        dz: float = 0.102,
+        interpkr: int = 10,
+        bUserBackground: bool = False,
+        background: float = 90,
+        NA: float = 1.25,
+        NIMM: float = 1.3,
+        dr: float = 0.102,
+        krmax: int = 0,
+        bDoCleanup: bool = False,
+    ) -> None:
+        """Make OTF file(s) from `ifiles`, write to `ofiles`."""
 
-@otf_lib.function
-def makeOTF(
-    ifiles: bytes,
-    ofiles: bytes,
-    lambdanm: int = 520,
-    dz: float = 0.102,
-    interpkr: int = 10,
-    bUserBackground: bool = False,
-    background: float = 90,
-    NA: float = 1.25,
-    NIMM: float = 1.3,
-    dr: float = 0.102,
-    krmax: int = 0,
-    bDoCleanup: bool = False,
-    b3Dout: bool = False,
-):
-    """Make OTF file(s) from `ifiles`, write to `ofiles`."""
+else:
+    @otf_lib.function
+    def makeOTF(
+        ifiles: bytes,
+        ofiles: bytes,
+        lambdanm: int = 520,
+        dz: float = 0.102,
+        interpkr: int = 10,
+        bUserBackground: bool = False,
+        background: float = 90,
+        NA: float = 1.25,
+        NIMM: float = 1.3,
+        dr: float = 0.102,
+        krmax: int = 0,
+        bDoCleanup: bool = False,
+        b3Dout: bool = False,
+    ) -> None:
+        """Make OTF file(s) from `ifiles`, write to `ofiles`."""

--- a/src/pycudadecon/_libwrap.py
+++ b/src/pycudadecon/_libwrap.py
@@ -252,7 +252,7 @@ except FileNotFoundError:
         "Please try `conda install -c conda-forge cudadecon`."
     ) from None
 
-if lib.version and lib.version < (0, 7):
+if otf_lib.version and otf_lib.version < (0, 7):
 
     @otf_lib.function
     def makeOTF(

--- a/src/pycudadecon/_libwrap.py
+++ b/src/pycudadecon/_libwrap.py
@@ -263,5 +263,6 @@ def makeOTF(
     dr: float = 0.102,
     krmax: int = 0,
     bDoCleanup: bool = False,
+    b3Dout: bool = False,
 ):
     """Make OTF file(s) from `ifiles`, write to `ofiles`."""

--- a/src/pycudadecon/deconvolution.py
+++ b/src/pycudadecon/deconvolution.py
@@ -488,6 +488,7 @@ def decon(
         fixorigin=fixorigin,
         cleanup_otf=cleanup_otf,
         max_otf_size=max_otf_size,
+        skewed_decon=skewed_decon,
     ) as otf:
         arraygen = _yield_arrays(images, fpattern)
         # first, assume that all of the images are the same shape...

--- a/src/pycudadecon/otf.py
+++ b/src/pycudadecon/otf.py
@@ -142,7 +142,7 @@ class CappedPSF:
                 pass
 
 
-if lib.version < (0, 7):
+if lib.lib.version and lib.lib.version < (0, 7):
 
     def make_otf(
         psf: str,

--- a/src/pycudadecon/otf.py
+++ b/src/pycudadecon/otf.py
@@ -158,6 +158,7 @@ if lib.lib.version and lib.lib.version < (0, 7):
         cleanup_otf: bool = False,
         max_otf_size: int = 60000,
         skewed_decon: bool = False,
+        **kwargs: Any,
     ) -> str:
         """Generate a radially averaged OTF file from a PSF file.
 
@@ -244,6 +245,7 @@ else:
         cleanup_otf: bool = False,
         max_otf_size: int = 60000,
         skewed_decon: bool = False,
+        **kwargs: Any,
     ) -> str:
         """Generate a radially averaged OTF file from a PSF file.
 

--- a/src/pycudadecon/otf.py
+++ b/src/pycudadecon/otf.py
@@ -208,22 +208,24 @@ def make_otf(
         bUserBackground = False
         background = 0.0
 
-    args: list = [str.encode(_psf.path),
-                str.encode(outpath),
-                wavelength,
-                dzpsf,
-                fixorigin,
-                bUserBackground,
-                background,
-                na,
-                nimm,
-                dxpsf,
-                krmax,
-                cleanup_otf]
+    args: list = [
+        str.encode(_psf.path),
+        str.encode(outpath),
+        wavelength,
+        dzpsf,
+        fixorigin,
+        bUserBackground,
+        background,
+        na,
+        nimm,
+        dxpsf,
+        krmax,
+        cleanup_otf,
+    ]
 
     if not lib.lib.version or lib.lib.version >= (0, 7):
         args += [skewed_decon]
-        
+
     with CappedPSF(psf, max_otf_size) as _psf:
         lib.makeOTF(*args)  # type: ignore
 

--- a/src/pycudadecon/otf.py
+++ b/src/pycudadecon/otf.py
@@ -156,6 +156,7 @@ def make_otf(
     cleanup_otf: bool = False,
     max_otf_size: int = 60000,
     skewed_decon: bool = False,
+    **kwargs: Any,
 ) -> str:
     """Generate a radially averaged OTF file from a PSF file.
 
@@ -192,7 +193,8 @@ def make_otf(
     skewed_decon : bool, optional
         generate 3D OTF instead of radially averaged OTF for deconvolution
         in skewed space
-
+    **kwargs : Any
+        additional keyword arguments are ignored
     Returns
     -------
     str

--- a/src/pycudadecon/otf.py
+++ b/src/pycudadecon/otf.py
@@ -152,7 +152,6 @@ def make_otf(
     cleanup_otf: bool = False,
     max_otf_size: int = 60000,
     skewed_decon: bool = False,
-    
     **kwargs: Any,
 ) -> str:
     """Generate a radially averaged OTF file from a PSF file.

--- a/src/pycudadecon/otf.py
+++ b/src/pycudadecon/otf.py
@@ -156,7 +156,6 @@ def make_otf(
     cleanup_otf: bool = False,
     max_otf_size: int = 60000,
     skewed_decon: bool = False,
-    **kwargs: Any,
 ) -> str:
     """Generate a radially averaged OTF file from a PSF file.
 
@@ -209,10 +208,7 @@ def make_otf(
         bUserBackground = False
         background = 0.0
 
-    with CappedPSF(psf, max_otf_size) as _psf:
-        if lib.lib.version and lib.lib.version < (0, 7):
-            lib.makeOTF(
-                str.encode(_psf.path),
+    args: list = [str.encode(_psf.path),
                 str.encode(outpath),
                 wavelength,
                 dzpsf,
@@ -223,25 +219,13 @@ def make_otf(
                 nimm,
                 dxpsf,
                 krmax,
-                cleanup_otf,
-            )
+                cleanup_otf]
 
-        else:
-            lib.makeOTF(
-                str.encode(_psf.path),
-                str.encode(outpath),
-                wavelength,
-                dzpsf,
-                fixorigin,
-                bUserBackground,
-                background,
-                na,
-                nimm,
-                dxpsf,
-                krmax,
-                cleanup_otf,
-                skewed_decon,
-            )
+    if not lib.lib.version or lib.lib.version >= (0, 7):
+        args += [skewed_decon]
+        
+    with CappedPSF(psf, max_otf_size) as _psf:
+        lib.makeOTF(*args)  # type: ignore
 
     return outpath
 

--- a/src/pycudadecon/otf.py
+++ b/src/pycudadecon/otf.py
@@ -191,9 +191,9 @@ if lib.lib.version and lib.lib.version < (0, 7):
             make sure OTF is smaller than this many bytes. Deconvolution
             may fail if the OTF is larger than 60KB (default: 60000)
         skewed_decon : bool, optional
-            generate 3D OTF instead of radially averaged OTF for deconvolution 
+            generate 3D OTF instead of radially averaged OTF for deconvolution
             in skewed space
-            
+
         Returns
         -------
         str
@@ -277,7 +277,7 @@ else:
             make sure OTF is smaller than this many bytes. Deconvolution
             may fail if the OTF is larger than 60KB (default: 60000)
         skewed_decon : bool, optional
-            generate 3D OTF instead of radially averaged OTF for deconvolution 
+            generate 3D OTF instead of radially averaged OTF for deconvolution
             in skewed space
 
         Returns

--- a/src/pycudadecon/otf.py
+++ b/src/pycudadecon/otf.py
@@ -151,6 +151,8 @@ def make_otf(
     fixorigin: int = 10,
     cleanup_otf: bool = False,
     max_otf_size: int = 60000,
+    skewed_decon: bool = False,
+    
     **kwargs: Any,
 ) -> str:
     """Generate a radially averaged OTF file from a PSF file.
@@ -185,6 +187,8 @@ def make_otf(
     max_otf_size : int, optional
         make sure OTF is smaller than this many bytes. Deconvolution
         may fail if the OTF is larger than 60KB (default: 60000), by default 60000
+    skewed_decon : bool, optional
+        generate 3D OTF instead of radially averaged OTF for deconvolution in skewed space
 
     Returns
     -------
@@ -215,6 +219,7 @@ def make_otf(
             dxpsf,
             krmax,
             cleanup_otf,
+            skewed_decon,
         )
 
     return outpath

--- a/src/pycudadecon/otf.py
+++ b/src/pycudadecon/otf.py
@@ -142,7 +142,7 @@ class CappedPSF:
                 pass
 
 
-if lib.version and lib.version < (0, 7):
+if lib.version < (0, 7):
 
     def make_otf(
         psf: str,

--- a/src/pycudadecon/otf.py
+++ b/src/pycudadecon/otf.py
@@ -137,75 +137,73 @@ class CappedPSF:
             except Exception:
                 pass
 
+if lib.version and lib.version < (0, 7):
 
-def make_otf(
-    psf: str,
-    outpath: Optional[str] = None,
-    dzpsf: float = 0.1,
-    dxpsf: float = 0.1,
-    wavelength: int = 520,
-    na: float = 1.25,
-    nimm: float = 1.3,
-    otf_bgrd: Optional[int] = None,
-    krmax: int = 0,
-    fixorigin: int = 10,
-    cleanup_otf: bool = False,
-    max_otf_size: int = 60000,
-    skewed_decon: bool = False,
-    **kwargs: Any,
-) -> str:
-    """Generate a radially averaged OTF file from a PSF file.
-
-    Parameters
-    ----------
-    psf : str
-        Filepath of 3D PSF TIF
-    outpath : str, optional
-        Destination filepath for the output OTF
-        (default: appends "_otf.tif" to filename), by default None
-    dzpsf : float, optional
-        Z-step size in microns, by default 0.1
-    dxpsf : float, optional
-        XY-Pixel size in microns, by default 0.1
-    wavelength : int, optional
-        Emission wavelength in nm, by default 520
-    na : float, optional
-        Numerical Aperture, by default 1.25
-    nimm : float, optional
-        Refractive indez of immersion medium, by default 1.3
-    otf_bgrd : int, optional
-        Background to subtract. "None" = autodetect., by default None
-    krmax : int, optional
-        pixels outside this limit will be zeroed (overwriting
-        estimated value from NA and NIMM), by default 0
-    fixorigin : int, optional
-        for all kz, extrapolate using pixels kr=1 to this pixel
-        to get value for kr=0, by default 10
-    cleanup_otf : bool, optional
-        clean-up outside OTF support, by default False
-    max_otf_size : int, optional
-        make sure OTF is smaller than this many bytes. Deconvolution
-        may fail if the OTF is larger than 60KB (default: 60000), by default 60000
-    skewed_decon : bool, optional
-        generate 3D OTF instead of radially averaged OTF for deconvolution in skewed space
-
-    Returns
-    -------
-    str
-        Path to the OTF file
-    """
-    if outpath is None:
-        outpath = psf.replace(".tif", "_otf.tif")
-
-    if otf_bgrd and isinstance(otf_bgrd, (int, float)):
-        bUserBackground = True
-        background = float(otf_bgrd)
-    else:
-        bUserBackground = False
-        background = 0.0
-
-    with CappedPSF(psf, max_otf_size) as _psf:
-        if lib.version and lib.version < (0, 7):
+    def make_otf(
+        psf: str,
+        outpath: Optional[str] = None,
+        dzpsf: float = 0.1,
+        dxpsf: float = 0.1,
+        wavelength: int = 520,
+        na: float = 1.25,
+        nimm: float = 1.3,
+        otf_bgrd: Optional[int] = None,
+        krmax: int = 0,
+        fixorigin: int = 10,
+        cleanup_otf: bool = False,
+        max_otf_size: int = 60000,
+        **kwargs: Any,
+    ) -> str:
+        """Generate a radially averaged OTF file from a PSF file.
+    
+        Parameters
+        ----------
+        psf : str
+            Filepath of 3D PSF TIF
+        outpath : str, optional
+            Destination filepath for the output OTF
+            (default: appends "_otf.tif" to filename), by default None
+        dzpsf : float, optional
+            Z-step size in microns, by default 0.1
+        dxpsf : float, optional
+            XY-Pixel size in microns, by default 0.1
+        wavelength : int, optional
+            Emission wavelength in nm, by default 520
+        na : float, optional
+            Numerical Aperture, by default 1.25
+        nimm : float, optional
+            Refractive indez of immersion medium, by default 1.3
+        otf_bgrd : int, optional
+            Background to subtract. "None" = autodetect., by default None
+        krmax : int, optional
+            pixels outside this limit will be zeroed (overwriting
+            estimated value from NA and NIMM), by default 0
+        fixorigin : int, optional
+            for all kz, extrapolate using pixels kr=1 to this pixel
+            to get value for kr=0, by default 10
+        cleanup_otf : bool, optional
+            clean-up outside OTF support, by default False
+        max_otf_size : int, optional
+            make sure OTF is smaller than this many bytes. Deconvolution
+            may fail if the OTF is larger than 60KB (default: 60000), by default 60000
+    
+        Returns
+        -------
+        str
+            Path to the OTF file
+        """
+        if outpath is None:
+            outpath = psf.replace(".tif", "_otf.tif")
+    
+        if otf_bgrd and isinstance(otf_bgrd, (int, float)):
+            bUserBackground = True
+            background = float(otf_bgrd)
+        else:
+            bUserBackground = False
+            background = 0.0
+    
+        with CappedPSF(psf, max_otf_size) as _psf:
+        
             lib.makeOTF(
                 str.encode(_psf.path),
                 str.encode(outpath),
@@ -219,8 +217,80 @@ def make_otf(
                 dxpsf,
                 krmax,
                 cleanup_otf)
+                
+        return outpath
+
+else:
+    
+    def make_otf(
+        psf: str,
+        outpath: Optional[str] = None,
+        dzpsf: float = 0.1,
+        dxpsf: float = 0.1,
+        wavelength: int = 520,
+        na: float = 1.25,
+        nimm: float = 1.3,
+        otf_bgrd: Optional[int] = None,
+        krmax: int = 0,
+        fixorigin: int = 10,
+        cleanup_otf: bool = False,
+        max_otf_size: int = 60000,
+        skewed_decon: bool = False,
+        **kwargs: Any,
+    ) -> str:
+        """Generate a radially averaged OTF file from a PSF file.
+    
+        Parameters
+        ----------
+        psf : str
+            Filepath of 3D PSF TIF
+        outpath : str, optional
+            Destination filepath for the output OTF
+            (default: appends "_otf.tif" to filename), by default None
+        dzpsf : float, optional
+            Z-step size in microns, by default 0.1
+        dxpsf : float, optional
+            XY-Pixel size in microns, by default 0.1
+        wavelength : int, optional
+            Emission wavelength in nm, by default 520
+        na : float, optional
+            Numerical Aperture, by default 1.25
+        nimm : float, optional
+            Refractive indez of immersion medium, by default 1.3
+        otf_bgrd : int, optional
+            Background to subtract. "None" = autodetect., by default None
+        krmax : int, optional
+            pixels outside this limit will be zeroed (overwriting
+            estimated value from NA and NIMM), by default 0
+        fixorigin : int, optional
+            for all kz, extrapolate using pixels kr=1 to this pixel
+            to get value for kr=0, by default 10
+        cleanup_otf : bool, optional
+            clean-up outside OTF support, by default False
+        max_otf_size : int, optional
+            make sure OTF is smaller than this many bytes. Deconvolution
+            may fail if the OTF is larger than 60KB (default: 60000), by default 60000
+        skewed_decon : bool, optional
+            generate 3D OTF instead of radially averaged OTF for deconvolution in skewed space
+    
+        Returns
+        -------
+        str
+            Path to the OTF file
+        """
+        if outpath is None:
+            outpath = psf.replace(".tif", "_otf.tif")
+    
+        if otf_bgrd and isinstance(otf_bgrd, (int, float)):
+            bUserBackground = True
+            background = float(otf_bgrd)
         else:
-             lib.makeOTF(
+            bUserBackground = False
+            background = 0.0
+    
+        with CappedPSF(psf, max_otf_size) as _psf:
+        
+            lib.makeOTF(
                 str.encode(_psf.path),
                 str.encode(outpath),
                 wavelength,
@@ -234,8 +304,8 @@ def make_otf(
                 krmax,
                 cleanup_otf,
                 skewed_decon)
-            
-    return outpath
+                
+        return outpath
 
 
 class TemporaryOTF:

--- a/src/pycudadecon/otf.py
+++ b/src/pycudadecon/otf.py
@@ -7,7 +7,7 @@ from typing import Any, Optional
 import numpy as np
 import tifffile as tf
 
-from . import lib
+from . import otf_lib
 from .util import PathOrArray, imread, is_otf
 
 
@@ -142,7 +142,7 @@ class CappedPSF:
                 pass
 
 
-if lib.version and lib.version < (0, 7):
+if otf_lib.version and otf_lib.version < (0, 7):
 
     def make_otf(
         psf: str,
@@ -208,7 +208,7 @@ if lib.version and lib.version < (0, 7):
             background = 0.0
 
         with CappedPSF(psf, max_otf_size) as _psf:
-            lib.makeOTF(
+            otf_lib.makeOTF(
                 str.encode(_psf.path),
                 str.encode(outpath),
                 wavelength,
@@ -294,7 +294,7 @@ else:
             background = 0.0
 
         with CappedPSF(psf, max_otf_size) as _psf:
-            lib.makeOTF(
+            otf_lib.makeOTF(
                 str.encode(_psf.path),
                 str.encode(outpath),
                 wavelength,

--- a/src/pycudadecon/otf.py
+++ b/src/pycudadecon/otf.py
@@ -195,6 +195,7 @@ def make_otf(
         in skewed space
     **kwargs : Any
         additional keyword arguments are ignored
+
     Returns
     -------
     str

--- a/src/pycudadecon/otf.py
+++ b/src/pycudadecon/otf.py
@@ -141,6 +141,7 @@ class CappedPSF:
             except Exception:
                 pass
 
+
 if lib.version and lib.version < (0, 7):
 
     def make_otf(
@@ -159,7 +160,7 @@ if lib.version and lib.version < (0, 7):
         **kwargs: Any,
     ) -> str:
         """Generate a radially averaged OTF file from a PSF file.
-    
+
         Parameters
         ----------
         psf : str
@@ -190,7 +191,7 @@ if lib.version and lib.version < (0, 7):
         max_otf_size : int, optional
             make sure OTF is smaller than this many bytes. Deconvolution
             may fail if the OTF is larger than 60KB (default: 60000), by default 60000
-    
+
         Returns
         -------
         str
@@ -198,16 +199,15 @@ if lib.version and lib.version < (0, 7):
         """
         if outpath is None:
             outpath = psf.replace(".tif", "_otf.tif")
-    
+
         if otf_bgrd and isinstance(otf_bgrd, (int, float)):
             bUserBackground = True
             background = float(otf_bgrd)
         else:
             bUserBackground = False
             background = 0.0
-    
+
         with CappedPSF(psf, max_otf_size) as _psf:
-        
             lib.makeOTF(
                 str.encode(_psf.path),
                 str.encode(outpath),
@@ -220,12 +220,13 @@ if lib.version and lib.version < (0, 7):
                 nimm,
                 dxpsf,
                 krmax,
-                cleanup_otf)
-                
+                cleanup_otf,
+            )
+
         return outpath
 
 else:
-    
+
     def make_otf(
         psf: str,
         outpath: Optional[str] = None,
@@ -243,7 +244,7 @@ else:
         **kwargs: Any,
     ) -> str:
         """Generate a radially averaged OTF file from a PSF file.
-    
+
         Parameters
         ----------
         psf : str
@@ -276,7 +277,7 @@ else:
             may fail if the OTF is larger than 60KB (default: 60000), by default 60000
         skewed_decon : bool, optional
             generate 3D OTF instead of radially averaged OTF for deconvolution in skewed space
-    
+
         Returns
         -------
         str
@@ -284,16 +285,15 @@ else:
         """
         if outpath is None:
             outpath = psf.replace(".tif", "_otf.tif")
-    
+
         if otf_bgrd and isinstance(otf_bgrd, (int, float)):
             bUserBackground = True
             background = float(otf_bgrd)
         else:
             bUserBackground = False
             background = 0.0
-    
+
         with CappedPSF(psf, max_otf_size) as _psf:
-        
             lib.makeOTF(
                 str.encode(_psf.path),
                 str.encode(outpath),
@@ -307,8 +307,9 @@ else:
                 dxpsf,
                 krmax,
                 cleanup_otf,
-                skewed_decon)
-                
+                skewed_decon,
+            )
+
         return outpath
 
 

--- a/src/pycudadecon/otf.py
+++ b/src/pycudadecon/otf.py
@@ -189,8 +189,11 @@ if lib.lib.version and lib.lib.version < (0, 7):
             clean-up outside OTF support, by default False
         max_otf_size : int, optional
             make sure OTF is smaller than this many bytes. Deconvolution
-            may fail if the OTF is larger than 60KB (default: 60000), by default 60000
-
+            may fail if the OTF is larger than 60KB (default: 60000)
+        skewed_decon : bool, optional
+            generate 3D OTF instead of radially averaged OTF for deconvolution 
+            in skewed space
+            
         Returns
         -------
         str
@@ -272,9 +275,10 @@ else:
             clean-up outside OTF support, by default False
         max_otf_size : int, optional
             make sure OTF is smaller than this many bytes. Deconvolution
-            may fail if the OTF is larger than 60KB (default: 60000), by default 60000
+            may fail if the OTF is larger than 60KB (default: 60000)
         skewed_decon : bool, optional
-            generate 3D OTF instead of radially averaged OTF for deconvolution in skewed space
+            generate 3D OTF instead of radially averaged OTF for deconvolution 
+            in skewed space
 
         Returns
         -------

--- a/src/pycudadecon/otf.py
+++ b/src/pycudadecon/otf.py
@@ -157,6 +157,7 @@ if lib.lib.version and lib.lib.version < (0, 7):
         fixorigin: int = 10,
         cleanup_otf: bool = False,
         max_otf_size: int = 60000,
+        skewed_decon: bool = False,
     ) -> str:
         """Generate a radially averaged OTF file from a PSF file.
 

--- a/src/pycudadecon/otf.py
+++ b/src/pycudadecon/otf.py
@@ -157,7 +157,6 @@ if lib.lib.version and lib.lib.version < (0, 7):
         fixorigin: int = 10,
         cleanup_otf: bool = False,
         max_otf_size: int = 60000,
-        **kwargs: Any,
     ) -> str:
         """Generate a radially averaged OTF file from a PSF file.
 
@@ -241,7 +240,6 @@ else:
         cleanup_otf: bool = False,
         max_otf_size: int = 60000,
         skewed_decon: bool = False,
-        **kwargs: Any,
     ) -> str:
         """Generate a radially averaged OTF file from a PSF file.
 

--- a/src/pycudadecon/otf.py
+++ b/src/pycudadecon/otf.py
@@ -7,7 +7,7 @@ from typing import Any, Optional
 import numpy as np
 import tifffile as tf
 
-from . import otf_lib
+from . import lib
 from .util import PathOrArray, imread, is_otf
 
 
@@ -142,7 +142,7 @@ class CappedPSF:
                 pass
 
 
-if otf_lib.version and otf_lib.version < (0, 7):
+if lib.version and lib.version < (0, 7):
 
     def make_otf(
         psf: str,
@@ -208,7 +208,7 @@ if otf_lib.version and otf_lib.version < (0, 7):
             background = 0.0
 
         with CappedPSF(psf, max_otf_size) as _psf:
-            otf_lib.makeOTF(
+            lib.makeOTF(
                 str.encode(_psf.path),
                 str.encode(outpath),
                 wavelength,
@@ -294,7 +294,7 @@ else:
             background = 0.0
 
         with CappedPSF(psf, max_otf_size) as _psf:
-            otf_lib.makeOTF(
+            lib.makeOTF(
                 str.encode(_psf.path),
                 str.encode(outpath),
                 wavelength,

--- a/src/pycudadecon/otf.py
+++ b/src/pycudadecon/otf.py
@@ -208,25 +208,26 @@ def make_otf(
         bUserBackground = False
         background = 0.0
 
-    args: list = [
-        str.encode(_psf.path),
-        str.encode(outpath),
-        wavelength,
-        dzpsf,
-        fixorigin,
-        bUserBackground,
-        background,
-        na,
-        nimm,
-        dxpsf,
-        krmax,
-        cleanup_otf,
-    ]
-
-    if not lib.lib.version or lib.lib.version >= (0, 7):
-        args += [skewed_decon]
-
     with CappedPSF(psf, max_otf_size) as _psf:
+    
+        args = [
+            str.encode(_psf.path),
+            str.encode(outpath),
+            wavelength,
+            dzpsf,
+            fixorigin,
+            bUserBackground,
+            background,
+            na,
+            nimm,
+            dxpsf,
+            krmax,
+            cleanup_otf,
+        ]
+    
+        if not lib.lib.version or lib.lib.version >= (0, 7):
+            args += [skewed_decon]
+
         lib.makeOTF(*args)  # type: ignore
 
     return outpath

--- a/src/pycudadecon/otf.py
+++ b/src/pycudadecon/otf.py
@@ -209,7 +209,6 @@ def make_otf(
         background = 0.0
 
     with CappedPSF(psf, max_otf_size) as _psf:
-    
         args = [
             str.encode(_psf.path),
             str.encode(outpath),
@@ -224,7 +223,7 @@ def make_otf(
             krmax,
             cleanup_otf,
         ]
-    
+
         if not lib.lib.version or lib.lib.version >= (0, 7):
             args += [skewed_decon]
 

--- a/src/pycudadecon/otf.py
+++ b/src/pycudadecon/otf.py
@@ -205,22 +205,36 @@ def make_otf(
         background = 0.0
 
     with CappedPSF(psf, max_otf_size) as _psf:
-        lib.makeOTF(
-            str.encode(_psf.path),
-            str.encode(outpath),
-            wavelength,
-            dzpsf,
-            fixorigin,
-            bUserBackground,
-            background,
-            na,
-            nimm,
-            dxpsf,
-            krmax,
-            cleanup_otf,
-            skewed_decon,
-        )
-
+        if lib.version and lib.version < (0, 7):
+            lib.makeOTF(
+                str.encode(_psf.path),
+                str.encode(outpath),
+                wavelength,
+                dzpsf,
+                fixorigin,
+                bUserBackground,
+                background,
+                na,
+                nimm,
+                dxpsf,
+                krmax,
+                cleanup_otf)
+        else:
+             lib.makeOTF(
+                str.encode(_psf.path),
+                str.encode(outpath),
+                wavelength,
+                dzpsf,
+                fixorigin,
+                bUserBackground,
+                background,
+                na,
+                nimm,
+                dxpsf,
+                krmax,
+                cleanup_otf,
+                skewed_decon)
+            
     return outpath
 
 

--- a/src/pycudadecon/otf.py
+++ b/src/pycudadecon/otf.py
@@ -210,9 +210,7 @@ def make_otf(
         background = 0.0
 
     with CappedPSF(psf, max_otf_size) as _psf:
-
         if lib.lib.version and lib.lib.version < (0, 7):
-    
             lib.makeOTF(
                 str.encode(_psf.path),
                 str.encode(outpath),
@@ -229,7 +227,6 @@ def make_otf(
             )
 
         else:
-
             lib.makeOTF(
                 str.encode(_psf.path),
                 str.encode(outpath),


### PR DESCRIPTION
Allow 3D OTF generation after changes have been added to radial_interface.cpp in cudadecon