### PR TITLE
feat: support get_version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,7 +100,7 @@ skip-magic-trailing-comma = false # default is false
 [tool.pytest.ini_options]
 minversion = "7.0"
 testpaths = ["tests"]
-filterwarnings = ["error"]
+filterwarnings = ["error", "ignore:Unable to find function"]
 
 # https://mypy.readthedocs.io/en/stable/config_file.html
 [tool.mypy]

--- a/src/pycudadecon/__init__.py
+++ b/src/pycudadecon/__init__.py
@@ -19,7 +19,7 @@ except FileNotFoundError as e:
     import warnings
 
     t = e
-    warnings.warn(f"\n{e}\n\nMost functionality will fail!\n", stacklevel=2)
+    warnings.warn(f"\n\n{e}\n\nMost functionality will fail!\n", stacklevel=2)
 
     class _stub:
         def __getattr__(self, name: str) -> Any:

--- a/src/pycudadecon/_libwrap.py
+++ b/src/pycudadecon/_libwrap.py
@@ -1,27 +1,13 @@
 import os
 from pathlib import Path
-from typing import Tuple
 
 import numpy as np
 from typing_extensions import Annotated
 
 from ._ctyped import Library
 
-# FIXME: ugly... we should export version better from cudadecon
-_cudadecon_version: Tuple[int, ...] = (0, 0, 0)
-_conda_prefix = os.getenv("CONDA_PREFIX")
-if _conda_prefix:
-    conda_meta = Path(_conda_prefix) / "conda-meta"
-    if conda_meta.exists():
-        fname = next(conda_meta.glob("cudadecon*.json"), None)
-        if fname is not None:
-            name, *rest = fname.stem.split("-")
-            abistring = rest[0] if rest else None
-            if abistring:
-                _cudadecon_version = tuple(int(x) for x in abistring.split("."))
-
 try:
-    lib = Library("libcudaDecon", version=_cudadecon_version)
+    lib = Library("libcudaDecon")
 except FileNotFoundError:
     raise FileNotFoundError(
         "Unable to find library 'lidbcudaDecon'\n"
@@ -30,6 +16,29 @@ except FileNotFoundError:
 
 
 ndarray_uint16 = Annotated[np.ndarray, "uint16"]
+
+
+@lib.function
+def get_version() -> bytes:  # type: ignore [empty-body]
+    """Return the version of the cudadecon library. Example b'0.7.0'."""
+
+
+try:
+    version = get_version().decode("utf-8")
+    lib.version_string = version
+except Exception:
+    # the shared library doesn't have the function get_version
+    # try to find it in the conda-meta directory
+    _conda_prefix = os.getenv("CONDA_PREFIX")
+    if _conda_prefix:
+        conda_meta = Path(_conda_prefix) / "conda-meta"
+        if conda_meta.exists():
+            fname = next(conda_meta.glob("cudadecon*.json"), None)
+            if fname is not None:
+                name, *rest = fname.stem.split("-")
+                _version = rest[0] if rest else None
+                if _version:
+                    lib.version_string = _version
 
 
 @lib.function
@@ -46,7 +55,7 @@ def camcor_interface(  # type: ignore [empty-body]
     """Execute camera corrections."""
 
 
-if _cudadecon_version < (0, 6):
+if lib.version < (0, 6):
 
     @lib.function
     def RL_interface_init(  # type: ignore [empty-body]
@@ -113,7 +122,7 @@ else:  # include "bSkewDecon" argument
         """
 
 
-if _cudadecon_version < (0, 6):
+if lib.version < (0, 6):
 
     @lib.function
     def RL_interface(  # type: ignore [empty-body]


### PR DESCRIPTION
supports https://github.com/scopetools/cudadecon/pull/36

and also fails a bit more gracefully/lazily if a specific symbol isn't found